### PR TITLE
Use class_eval over define_method

### DIFF
--- a/lib/seismograph/gateway.rb
+++ b/lib/seismograph/gateway.rb
@@ -4,7 +4,7 @@ module Seismograph
   module Gateway
     class << self
       [:histogram, :increment, :decrement, :time, :event].each do |method|
-        class_eval <<-RUBY, __FILE__, __LINE__
+        class_eval <<-RUBY, __FILE__, __LINE__+1
           def #{method}(*a, &b)
             client.send(:#{method}, *a, &b)
           end

--- a/lib/seismograph/log.rb
+++ b/lib/seismograph/log.rb
@@ -6,7 +6,7 @@ module Seismograph
       include Parameterize
 
       [:info, :error, :warning, :success].each do |alert_type|
-        class_eval <<-RUBY, __FILE__, __LINE__
+        class_eval <<-RUBY, __FILE__, __LINE__+1
           def #{alert_type}(message, params = {})
             description = params.delete(:description) || ''
             log(message, description, params.merge(alert_type: "#{alert_type}"))


### PR DESCRIPTION
Calling methods defined by `#define_method` is about 30% slower than calling a
method defined normally, or one defined inside a `class_eval`

Benchmarks: https://github.com/paul/benchmarks/blob/master/eval_def_method.rb#L54

Alternatively, a cleaner way to do this if performance is not a concern is to
use [Forwardable from the Ruby stdlib](http://ruby-doc.org/stdlib-2.0.0/libdoc/forwardable/rdoc/Forwardable.html).
