### PR TITLE
Adds 'enabled' config property and testing module

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ task :deploy do
 end
 ```
 
+### Test Environment:
+
+To disable seismograph in your test environment, include this file in your test helper:
+
+`require 'seismograph/testing'`
+
 ## Contributing
 
 1. Fork it

--- a/lib/seismograph/configuration.rb
+++ b/lib/seismograph/configuration.rb
@@ -1,20 +1,21 @@
 module Seismograph
   class Configuration
-    attr_writer :statsd_host
-    attr_writer :statsd_port
-    attr_writer :app_name
-    attr_writer :env
+    attr_accessor :enabled
 
-    def statsd_host=(host)
-      @statsd_host = host
+    def initialize
+      self.enabled = true
     end
 
-    def statsd_port=(port)
-      @statsd_port = port.to_s
+    def app_name
+      @app_name || fail('No app_name configured')
     end
 
     def app_name=(name)
       @app_name = name
+    end
+
+    def env
+      @env || ENV['RAILS_ENV'] || ENV['RACK_ENV']
     end
 
     def env=(env)
@@ -25,16 +26,16 @@ module Seismograph
       @statsd_host || fail('No statsd_host configured')
     end
 
+    def statsd_host=(host)
+      @statsd_host = host
+    end
+
     def statsd_port
       @statsd_port || fail('No statsd_port configured')
     end
 
-    def app_name
-      @app_name || fail('No app_name configured')
-    end
-
-    def env
-      @env || ENV['RAILS_ENV'] || ENV['RACK_ENV']
+    def statsd_port=(port)
+      @statsd_port = port.to_s
     end
   end
 end

--- a/lib/seismograph/gateway.rb
+++ b/lib/seismograph/gateway.rb
@@ -2,11 +2,13 @@ require 'statsd'
 
 module Seismograph
   module Gateway
+    GATEWAY_METHODS = [:histogram, :increment, :decrement, :time, :timing, :event, :gauge].freeze
+
     class << self
-      [:histogram, :increment, :decrement, :time, :timing, :event, :gauge].each do |method|
+      GATEWAY_METHODS.each do |method|
         class_eval <<-RUBY, __FILE__, __LINE__+1
           def #{method}(*a, &b)
-            client.send(:#{method}, *a, &b)
+            client.send(:#{method}, *a, &b) if Seismograph.config.enabled
           end
         RUBY
       end

--- a/lib/seismograph/log.rb
+++ b/lib/seismograph/log.rb
@@ -1,3 +1,4 @@
+require 'seismograph/gateway'
 require 'seismograph/parameterize'
 
 module Seismograph

--- a/lib/seismograph/testing.rb
+++ b/lib/seismograph/testing.rb
@@ -1,0 +1,3 @@
+require 'seismograph'
+
+Seismograph.config.enabled = false

--- a/lib/seismograph/version.rb
+++ b/lib/seismograph/version.rb
@@ -1,3 +1,3 @@
 module Seismograph
-  VERSION = '0.3.3'
+  VERSION = '0.3.4'
 end

--- a/seismograph.gemspec
+++ b/seismograph.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dogstatsd-ruby', '~> 1.5'
 
   spec.add_development_dependency 'pry-nav'
-  spec.add_development_dependency 'bundler', '~> 1.11.0'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rspec-its', '~> 1.2'

--- a/spec/seismograph/sensor_spec.rb
+++ b/spec/seismograph/sensor_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe Seismograph::Sensor do
     end
   end
 
+  context 'when enabled is false' do
+    around do |example|
+      begin
+        Seismograph.config.enabled = false
+        example.run
+      ensure
+        Seismograph.config.enabled = true
+      end
+    end
+
+    it 'does not call client' do
+      subject.increment('metric', tags: 'sometag')
+      expect(client_double).to_not have_received(:increment)
+    end
+  end
+
   describe '#increment' do
     it 'accepts tags' do
       subject.increment('metric', tags: 'sometag')


### PR DESCRIPTION
Now seismograph can be disabled via config or by `require
'seismograph/testing'`

Also reordered Configuration methods