### PR TITLE
circle 2 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/seismograph
+    docker:
+      - image: kapost/ruby:2.4.3-node-6.11.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run: bundle exec rspec --format documentation --color spec

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-dependencies:
-  pre:
-    - gem install bundler -v 1.11.2


### PR DESCRIPTION
Circle is sunsetting 1.0 builds and configs effective August 31, 2018. This gets seismograph on circle 2.0

## Jira Issue
https://kapost.atlassian.net/browse/DEVOPS-1049